### PR TITLE
Fix: Implement missing modifyQueryUsing() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-10-23
+
+### Fixed
+- 🐛 Implemented missing `modifyQueryUsing()` method that was documented but not functional ([#1](https://github.com/openplain/filament-tree-view/issues/1))
+- 🐛 Fixed `getTreeRecords()` to respect configured query modifications
+
+### Added
+- ✅ Added test coverage for `modifyQueryUsing()` method
+
+## [0.1.1] - 2025-10-23
+
 ## [0.1.0] - 2025-01-15
 
 ### Added
@@ -47,5 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Built on [staudenmeir/laravel-adjacency-list](https://github.com/staudenmeir/laravel-adjacency-list)
 - Built with [Pragmatic Drag & Drop](https://atlassian.design/components/pragmatic-drag-and-drop) by Atlassian
 
-[Unreleased]: https://github.com/openplain/filament-tree-view/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/openplain/filament-tree-view/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/openplain/filament-tree-view/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/openplain/filament-tree-view/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/openplain/filament-tree-view/releases/tag/v0.1.0

--- a/src/Concerns/InteractsWithTree.php
+++ b/src/Concerns/InteractsWithTree.php
@@ -50,10 +50,10 @@ trait InteractsWithTree
 
     public function getTreeRecords(): array
     {
-        $modelClass = $this->getTree()->getQuery()->getModel()::class;
+        $query = $this->getTree()->getQuery();
 
-        // Get all records ordered
-        $nodes = $modelClass::query()
+        // Get all records ordered, using the configured query
+        $nodes = (clone $query)
             ->orderBy('order')
             ->orderBy('id')
             ->get();

--- a/src/Tree/Concerns/HasQuery.php
+++ b/src/Tree/Concerns/HasQuery.php
@@ -10,6 +10,8 @@ trait HasQuery
 {
     protected Builder|Relation|Closure|null $query = null;
 
+    protected ?Closure $queryModifier = null;
+
     protected ?string $modelLabel = null;
 
     protected ?string $pluralModelLabel = null;
@@ -17,6 +19,13 @@ trait HasQuery
     public function query(Builder|Relation|Closure|null $query): static
     {
         $this->query = $query;
+
+        return $this;
+    }
+
+    public function modifyQueryUsing(?Closure $callback): static
+    {
+        $this->queryModifier = $callback;
 
         return $this;
     }
@@ -37,7 +46,15 @@ trait HasQuery
 
     public function getQuery(): Builder|Relation|null
     {
-        return $this->evaluate($this->query);
+        $query = $this->evaluate($this->query);
+
+        if ($query && $this->queryModifier) {
+            $query = $this->evaluate($this->queryModifier, [
+                'query' => $query,
+            ]);
+        }
+
+        return $query;
     }
 
     public function getModelLabel(): ?string

--- a/tests/Unit/TreeConfigurationTest.php
+++ b/tests/Unit/TreeConfigurationTest.php
@@ -94,3 +94,22 @@ it('can set record actions', function () {
 
     expect($tree->getRecordActions())->toHaveCount(2);
 });
+
+it('can modify query using closure', function () {
+    $livewire = Mockery::mock('Openplain\FilamentTreeView\Contracts\HasTree');
+
+    // Create a mock query builder
+    $mockQuery = Mockery::mock('Illuminate\Database\Eloquent\Builder');
+    $mockQuery->shouldReceive('where')->with('status', 'active')->once()->andReturnSelf();
+    $mockQuery->shouldReceive('orderBy')->with('name')->once()->andReturnSelf();
+
+    $tree = Tree::make($livewire)
+        ->query($mockQuery)
+        ->modifyQueryUsing(fn ($query) => $query->where('status', 'active')->orderBy('name'));
+
+    // Trigger query evaluation
+    $tree->getQuery();
+
+    // Mockery will automatically verify the expectations
+    expect(true)->toBeTrue();
+});


### PR DESCRIPTION
Resolves #1

The modifyQueryUsing() method was documented in README.md but was never actually implemented in the HasQuery trait. This caused confusion for users trying to filter their tree views.

Changes:
- Add modifyQueryUsing() method to HasQuery trait
- Add $queryModifier property to store the query modification callback
- Update getQuery() to apply query modifications when present
- Fix getTreeRecords() to use the configured query instead of creating a fresh one
- Add test coverage for modifyQueryUsing() functionality

The method now works as documented, allowing users to filter and customize tree queries like this:

    ->modifyQueryUsing(fn ($query) => $query
        ->where('status', 'active')
        ->orderBy('name')
    )