### PR TITLE
Feature: Implement missing Field methods documented in README

### DIFF
--- a/src/Fields/IconField.php
+++ b/src/Fields/IconField.php
@@ -37,12 +37,52 @@ class IconField extends Field
     }
 
     /**
+     * Set the icon for the true state.
+     */
+    public function trueIcon(string $icon): static
+    {
+        $this->trueIcon = $icon;
+
+        return $this;
+    }
+
+    /**
+     * Set the icon for the false state.
+     */
+    public function falseIcon(string $icon): static
+    {
+        $this->falseIcon = $icon;
+
+        return $this;
+    }
+
+    /**
      * Set custom colors for true/false states.
      */
     public function colors(string $trueColor, string $falseColor): static
     {
         $this->trueColor = $trueColor;
         $this->falseColor = $falseColor;
+
+        return $this;
+    }
+
+    /**
+     * Set the color for the true state.
+     */
+    public function trueColor(string $color): static
+    {
+        $this->trueColor = $color;
+
+        return $this;
+    }
+
+    /**
+     * Set the color for the false state.
+     */
+    public function falseColor(string $color): static
+    {
+        $this->falseColor = $color;
 
         return $this;
     }


### PR DESCRIPTION
This commit adds several methods that were documented in the README but not yet implemented in the codebase, resolving issue #3.

TextField enhancements:
- Add formatStateUsing() method to support custom state formatting with Closures
- Add size() method to control text size (xs, sm, base, lg, xl)
- Update color() to accept Closures in addition to strings for dynamic colors
- Update render() to evaluate Closures and apply formatting properly

IconField enhancements:
- Add trueIcon() method for individual true state icon configuration
- Add falseIcon() method for individual false state icon configuration
- Add trueColor() method for individual true state color configuration
- Add falseColor() method for individual false state color configuration

All methods follow Filament's fluent API pattern and maintain backward compatibility with existing code. All tests pass successfully.

Fixes #3