### PR TITLE
Fix: Resolve view caching issues and component location

### DIFF
--- a/resources/views/components/tree-node.blade.php
+++ b/resources/views/components/tree-node.blade.php
@@ -142,7 +142,7 @@
     @if ($hasChildren && $livewire->isExpanded($record->id))
         <div class="filament-tree-children">
             @foreach ($record->children as $child)
-                @include('filament-tree-view::tree-node', [
+                @include('filament-tree-view::components.tree-node', [
                     'record' => $child,
                     'depth' => $depth + 1,
                     'maxDepth' => $maxDepth,

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -25,7 +25,7 @@
             ></div>
         </div>
     @else
-        <x-filament-tables::empty-state
+        <x-filament::empty-state
             :actions="$tree->getEmptyStateActions()"
             :description="$tree->getEmptyStateDescription()"
             :heading="$tree->getEmptyStateHeading()"

--- a/resources/views/pages/tree-page.blade.php
+++ b/resources/views/pages/tree-page.blade.php
@@ -135,7 +135,7 @@
 
             <div class="filament-tree-container">
                 @foreach ($records as $record)
-                    @include('filament-tree-view::tree-node', [
+                    @include('filament-tree-view::components.tree-node', [
                         'record' => $record,
                         'depth' => 0,
                         'maxDepth' => $tree->getMaxDepth(),

--- a/src/FilamentTreeViewServiceProvider.php
+++ b/src/FilamentTreeViewServiceProvider.php
@@ -23,10 +23,12 @@ class FilamentTreeViewServiceProvider extends PackageServiceProvider
 
     public function packageBooted(): void
     {
-        // Register assets using Filament v4 pattern
+        // Register assets...
         FilamentAsset::register([
             Css::make('filament-tree-view-styles', __DIR__.'/../resources/dist/filament-tree-view.css'),
             Js::make('filament-tree-view-scripts', __DIR__.'/../resources/dist/filament-tree-view.js'),
         ], package: 'openplain/filament-tree-view');
+
     }
+
 }


### PR DESCRIPTION
`php artisan optimize` or `view:cach`e failed with error "Unable to locate a class or view for component [filament-tree-view::tree-node]" and later [filament-tables::empty-state].

Fix 1 (Structure): To align with Blade component conventions and fix the first error, the view was moved from resources/views/tree-node.blade.php to resources/views/components/tree-node.blade.php. The parent view was updated to use the new path (filament-tree-view::components.tree-node).

Fix 2 (Dependency): The internal, unstable component <x-filament-tables::empty-state /> was replaced with the public and stable <x-filament::empty-state /> component, which resolves the secondary caching failure.

Testing: Confirm that both php artisan optimize works and the component renders correctly on the front end.

Fixes #7 

