### PR TITLE
Add TreeRelationPage for managing tree relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,49 @@ That's it! You now have a fully functional drag-and-drop tree view with manual s
 
 ---
 
+## Relation Pages
+
+If you're using Filament's relation pages (extending `ManageRelatedRecords`), you can use `TreeRelationPage` instead of `TreePage`. This is ideal when you want to manage a hierarchical relationship separately from editing or viewing the owner record.
+
+### When to Use TreeRelationPage
+
+- You're using resource sub-navigation and want to switch between View/Edit pages and the relation page
+- You want to keep relationship management separate from the owner record
+- The tree configuration should come from the related resource, not the parent resource
+
+### Example: Managing Category Children
+
+```php
+<?php
+
+namespace App\Filament\Resources\CategoryResource\Pages;
+
+use App\Filament\Resources\CategoryResource;
+use Openplain\FilamentTreeView\Resources\Pages\TreeRelationPage;
+
+class ManageCategoryChildren extends TreeRelationPage
+{
+    protected static string $resource = CategoryResource::class;
+    protected static string $relationship = 'children';
+    protected static ?string $relatedResource = CategoryResource::class;
+}
+```
+
+Register the page in your resource:
+
+```php
+public static function getPages(): array
+{
+    return [
+        'index' => Pages\ListCategories::route('/'),
+        'create' => Pages\CreateCategory::route('/create'),
+        'view' => Pages\ViewCategory::route('/{record}'),
+        'edit' => Pages\EditCategory::route('/{record}/edit'),
+        'children' => Pages\ManageCategoryChildren::route('/{record}/children'),
+    ];
+}
+```
+
 ## Advanced Configuration
 
 Need more control? The tree view offers powerful customization options. **All configuration is optional** - only add what you need.

--- a/src/FilamentTreeViewServiceProvider.php
+++ b/src/FilamentTreeViewServiceProvider.php
@@ -30,5 +30,4 @@ class FilamentTreeViewServiceProvider extends PackageServiceProvider
         ], package: 'openplain/filament-tree-view');
 
     }
-
 }

--- a/src/Resources/Pages/TreeRelationPage.php
+++ b/src/Resources/Pages/TreeRelationPage.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Openplain\FilamentTreeView\Resources\Pages;
+
+use Closure;
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Resources\Pages\ManageRelatedRecords;
+use Filament\Schemas\Schema;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Openplain\FilamentTreeView\Concerns\InteractsWithTree;
+use Openplain\FilamentTreeView\Contracts\HasTree;
+use Openplain\FilamentTreeView\Tree;
+
+class TreeRelationPage extends ManageRelatedRecords implements HasTree
+{
+    use InteractsWithTree {
+        makeTree as makeBaseTree;
+    }
+
+    protected string $view = 'filament-tree-view::pages.tree-page';
+
+    public function getBreadcrumb(): string
+    {
+        return static::$breadcrumb ?? static::getRelationshipTitle();
+    }
+
+    public function tree(Tree $tree): Tree
+    {
+        return $tree;
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        if (filled(static::$title)) {
+            return static::$title;
+        }
+
+        $relatedResource = static::getRelatedResource();
+
+        if ($relatedResource) {
+            return $relatedResource::getTitleCasePluralModelLabel();
+        }
+
+        return parent::getTitle();
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        $relatedResource = static::getRelatedResource();
+
+        if (! $relatedResource) {
+            return $schema;
+        }
+
+        return $relatedResource::form($schema);
+    }
+
+    public function infolist(Schema $schema): Schema
+    {
+        $relatedResource = static::getRelatedResource();
+
+        if (! $relatedResource) {
+            return $schema;
+        }
+
+        return $relatedResource::infolist($schema);
+    }
+
+    public function getDefaultActionSchemaResolver(Action $action): ?Closure
+    {
+        return match (true) {
+            $action instanceof CreateAction, $action instanceof EditAction => fn (Schema $schema): Schema => $this->form($schema->columns(2)),
+            $action instanceof ViewAction => fn (Schema $schema): Schema => $this->infolist($this->form($schema->columns(2))),
+            default => null,
+        };
+    }
+
+    public function getDefaultActionUrl(Action $action): ?string
+    {
+        $relatedResource = static::getRelatedResource();
+
+        if (! $relatedResource) {
+            return null;
+        }
+
+        if (
+            ($action instanceof CreateAction) &&
+            ($relatedResource::hasPage('create'))
+        ) {
+            return $relatedResource::getUrl('create', shouldGuessMissingParameters: true);
+        }
+
+        if (
+            ($action instanceof EditAction) &&
+            ($relatedResource::hasPage('edit'))
+        ) {
+            return $relatedResource::getUrl('edit', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
+        }
+
+        if (
+            ($action instanceof ViewAction) &&
+            ($relatedResource::hasPage('view'))
+        ) {
+            return $relatedResource::getUrl('view', ['record' => $action->getRecord()], shouldGuessMissingParameters: true);
+        }
+
+        return null;
+    }
+
+    protected function makeTree(): Tree
+    {
+        $relatedResource = static::getRelatedResource();
+
+        $tree = $this->makeBaseTree()
+            ->query(fn (): Builder|Relation => $this->getTreeQuery())
+            ->when($this->getModelLabel(), fn (Tree $tree, string $modelLabel): Tree => $tree->modelLabel($modelLabel))
+            ->when($this->getPluralModelLabel(), fn (Tree $tree, string $pluralModelLabel): Tree => $tree->pluralModelLabel($pluralModelLabel))
+            ->recordAction(function (Model $record, Tree $tree): ?string {
+                foreach (['view', 'edit'] as $action) {
+                    $action = $tree->getAction($action);
+
+                    if (! $action) {
+                        continue;
+                    }
+
+                    $action->record($record);
+                    $action->getGroup()?->record($record);
+
+                    if ($action->isHidden()) {
+                        continue;
+                    }
+
+                    if ($action->getUrl()) {
+                        continue;
+                    }
+
+                    return $action->getName();
+                }
+
+                return null;
+            })
+            ->recordUrl(function (Model $record, Tree $tree): ?string {
+                foreach (['view', 'edit'] as $action) {
+                    $action = $tree->getAction($action);
+
+                    if (! $action) {
+                        continue;
+                    }
+
+                    $action->record($record);
+                    $action->getGroup()?->record($record);
+
+                    if ($action->isHidden()) {
+                        continue;
+                    }
+
+                    $url = $action->getUrl();
+
+                    if (! $url) {
+                        continue;
+                    }
+
+                    return $url;
+                }
+
+                $relatedResource = static::getRelatedResource();
+
+                if (! $relatedResource) {
+                    return null;
+                }
+
+                foreach (['view', 'edit'] as $action) {
+                    if (! $relatedResource::hasPage($action)) {
+                        continue;
+                    }
+
+                    if (! $relatedResource::{'can'.ucfirst($action)}($record)) {
+                        continue;
+                    }
+
+                    return $relatedResource::getUrl($action, ['record' => $record], shouldGuessMissingParameters: true);
+                }
+
+                return null;
+            });
+
+        if (! $relatedResource) {
+            return $tree;
+        }
+
+        return $relatedResource::tree($tree);
+    }
+
+    public function getTreeQuery(): Builder|Relation
+    {
+        return $this->getRelationship();
+    }
+
+    public function getModelLabel(): ?string
+    {
+        $relatedResource = static::getRelatedResource();
+
+        if (! $relatedResource) {
+            return null;
+        }
+
+        return $relatedResource::getModelLabel();
+    }
+
+    public function getPluralModelLabel(): ?string
+    {
+        $relatedResource = static::getRelatedResource();
+
+        if (! $relatedResource) {
+            return null;
+        }
+
+        return $relatedResource::getPluralModelLabel();
+    }
+}

--- a/tests/Feature/TreeRelationPageTest.php
+++ b/tests/Feature/TreeRelationPageTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Mockery;
+use Openplain\FilamentTreeView\Resources\Pages\TreeRelationPage;
+use Openplain\FilamentTreeView\Tests\Models\Category;
+use Openplain\FilamentTreeView\Tests\Resources\TestResource;
+
+beforeEach(function () {
+    // Create test data
+    $this->parentCategory = Category::factory()->create(['name' => 'Parent Category']);
+    $this->child1 = Category::factory()->withParent($this->parentCategory)->create(['name' => 'Child 1']);
+    $this->child2 = Category::factory()->withParent($this->parentCategory)->create(['name' => 'Child 2']);
+});
+
+it('uses relationship query instead of resource query', function () {
+    $page = new class($this->parentCategory) extends TreeRelationPage
+    {
+        protected static string $resource = TestResource::class;
+
+        protected static string $relationship = 'children';
+
+        protected static ?string $relatedResource = null;
+
+        public function mount(int|string $record): void
+        {
+            $this->record = Category::find($record);
+            parent::mount($record);
+        }
+    };
+
+    $page->mount($this->parentCategory->id);
+
+    $query = $page->getTreeQuery();
+    expect($query)->toBeInstanceOf(Relation::class);
+
+    // Verify it's scoped to the relationship
+    $records = $query->get();
+    expect($records)->toHaveCount(2);
+    expect($records->pluck('id'))->toContain($this->child1->id, $this->child2->id);
+    expect($records->pluck('id'))->not->toContain($this->parentCategory->id);
+});
+
+it('returns null for model labels when no related resource is set', function () {
+    $page = new class($this->parentCategory) extends TreeRelationPage
+    {
+        protected static string $resource = TestResource::class;
+
+        protected static string $relationship = 'children';
+
+        protected static ?string $relatedResource = null;
+
+        public function mount(int|string $record): void
+        {
+            $this->record = Category::find($record);
+            parent::mount($record);
+        }
+    };
+
+    $page->mount($this->parentCategory->id);
+
+    expect($page->getModelLabel())->toBeNull();
+    expect($page->getPluralModelLabel())->toBeNull();
+});
+
+it('returns schema when no related resource is set', function () {
+    $page = new class($this->parentCategory) extends TreeRelationPage
+    {
+        protected static string $resource = TestResource::class;
+
+        protected static string $relationship = 'children';
+
+        protected static ?string $relatedResource = null;
+
+        public function mount(int|string $record): void
+        {
+            $this->record = Category::find($record);
+            parent::mount($record);
+        }
+    };
+
+    $page->mount($this->parentCategory->id);
+
+    $schema = Mockery::mock('Filament\Schemas\Schema');
+    $formResult = $page->form($schema);
+    $infolistResult = $page->infolist($schema);
+
+    expect($formResult)->toBe($schema);
+    expect($infolistResult)->toBe($schema);
+});
+
+it('extends ManageRelatedRecords', function () {
+    $page = new class($this->parentCategory) extends TreeRelationPage
+    {
+        protected static string $resource = TestResource::class;
+
+        protected static string $relationship = 'children';
+
+        protected static ?string $relatedResource = null;
+    };
+
+    expect($page)->toBeInstanceOf(\Filament\Resources\Pages\ManageRelatedRecords::class);
+    expect($page)->toBeInstanceOf(\Openplain\FilamentTreeView\Contracts\HasTree::class);
+});
+
+it('uses the same view as TreePage', function () {
+    $page = new class($this->parentCategory) extends TreeRelationPage
+    {
+        protected static string $resource = TestResource::class;
+
+        protected static string $relationship = 'children';
+
+        protected static ?string $relatedResource = null;
+    };
+
+    $reflection = new ReflectionClass($page);
+    $viewProperty = $reflection->getProperty('view');
+    $viewProperty->setAccessible(true);
+    $view = $viewProperty->getValue($page);
+
+    expect($view)->toBe('filament-tree-view::pages.tree-page');
+});

--- a/tests/Resources/TestResource.php
+++ b/tests/Resources/TestResource.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Openplain\FilamentTreeView\Tests\Resources;
+
+use Filament\Resources\Resource;
+use Openplain\FilamentTreeView\Tests\Models\Category;
+
+class TestResource extends Resource
+{
+    protected static ?string $model = Category::class;
+
+    public static function getModel(): string
+    {
+        return Category::class;
+    }
+
+    public static function getEloquentQuery(): \Illuminate\Database\Eloquent\Builder
+    {
+        return Category::query();
+    }
+}
+

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,8 @@ namespace Openplain\FilamentTreeView\Tests;
 use BladeUI\Heroicons\BladeHeroiconsServiceProvider;
 use BladeUI\Icons\BladeIconsServiceProvider;
 use Filament\FilamentServiceProvider;
+use Filament\Panel;
+use Filament\PanelProvider;
 use Filament\Support\SupportServiceProvider;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -33,6 +35,7 @@ class TestCase extends Orchestra
             FilamentServiceProvider::class,
             SupportServiceProvider::class,
             FilamentTreeViewServiceProvider::class,
+            TestPanelProvider::class,
         ];
     }
 
@@ -59,5 +62,16 @@ class TestCase extends Orchestra
             $table->boolean('is_active')->default(true);
             $table->timestamps();
         });
+    }
+}
+
+class TestPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('test')
+            ->default()
+            ->path('admin');
     }
 }


### PR DESCRIPTION
Introduces TreeRelationPage, a new page type for managing hierarchical relationships on Filament relation pages, and documents its usage in the README. Adds feature tests and a test resource to ensure correct behavior, and registers a test panel provider for testing.