### PR TITLE
fix: restore mountedActions when Livewire re-hydrates during open modal

### DIFF
--- a/src/Concerns/InteractsWithTree.php
+++ b/src/Concerns/InteractsWithTree.php
@@ -21,11 +21,42 @@ trait InteractsWithTree
 
     public ?array $selectedRecords = [];
 
+    /**
+     * Snapshot of mountedActions captured during the boot phase, before
+     * bootedInteractsWithActions() can clear them. Tree record actions are not
+     * yet in cachedActions when bootedInteractsWithActions() runs (it comes from a
+     * parent class and therefore executes first), so caching fails and mountedActions
+     * is reset to []. bootedInteractsWithTree() uses this snapshot to restore the
+     * mounted action state after the tree has registered its actions.
+     *
+     * @var array<array<string, mixed>>
+     */
+    protected array $preMountedActionsSnapshot = [];
+
+    public function bootInteractsWithTree(): void
+    {
+        // Runs during Livewire's boot phase, before any bootedXxx() hooks fire.
+        // Capture mountedActions now so bootedInteractsWithTree() can restore them
+        // if bootedInteractsWithActions() cleared them.
+        $this->preMountedActionsSnapshot = $this->mountedActions ?? [];
+    }
+
     public function bootedInteractsWithTree(): void
     {
         $this->tree = $this->tree($this->makeTree());
 
-        $this->cacheMountedActions($this->mountedActions);
+        // bootedInteractsWithActions() runs before this method and may have cleared
+        // mountedActions when it failed to resolve tree actions (not yet registered).
+        // Restore from the snapshot captured in bootInteractsWithTree().
+        $actionsToRestore = ! empty($this->mountedActions)
+            ? $this->mountedActions
+            : $this->preMountedActionsSnapshot;
+
+        if (filled($actionsToRestore) && ! empty($this->cacheMountedActions($actionsToRestore))) {
+            $this->mountedActions = $actionsToRestore;
+        } else {
+            $this->cacheMountedActions($this->mountedActions);
+        }
     }
 
     public function tree(Tree $tree): Tree


### PR DESCRIPTION
## Problem

Any Livewire update that fires while a tree record action modal is open (ViewAction, EditAction, DeleteAction confirmation) causes the modal to silently close and, in the case of DeleteAction, prevents the confirmed action from executing.

**Affected scenarios:**
- Using a `LocaleSwitcher` (SelectAction with `wire:model.live`) placed in `extraModalFooterActions` of a ViewAction or EditAction
- Changing a `->live()` form field (e.g. `ToggleButtons`) inside an EditAction modal
- Clicking the "Confirm" button in a DeleteAction's built-in confirmation modal

## Root cause

Livewire's `class_uses_recursive()` processes parent-class traits before child-class traits. `InteractsWithActions` lives on Filament's `Page` class (a grandparent), so `bootedInteractsWithActions()` always runs **before** `bootedInteractsWithTree()`.

On every Livewire hydration cycle:

1. **`bootedInteractsWithActions()`** tries to resolve the currently-mounted action (e.g. `view`, `delete`) by looking it up in `$this->cachedActions`. Tree record actions are not registered there yet — that happens inside `bootedInteractsWithTree()`. The lookup throws `ActionNotResolvableException`, which is caught, and `mountedActions` is reset to `[]`. **The modal is now considered closed.**
2. **`bootedInteractsWithTree()`** builds the tree and registers its actions into `cachedActions` — but `mountedActions` is already empty.

## Fix

Add `bootInteractsWithTree()`, which runs during Livewire's **boot phase** (before any `bootedXxx()` hook). It snapshots `$this->mountedActions` before it can be cleared.

`bootedInteractsWithTree()` is updated to:
1. Build the tree (registering actions into `cachedActions`).
2. Attempt to restore `mountedActions` from the snapshot using `cacheMountedActions()`, which can now succeed because the actions are registered.

```php
public function bootInteractsWithTree(): void
{
    $this->preMountedActionsSnapshot = $this->mountedActions ?? [];
}

public function bootedInteractsWithTree(): void
{
    $this->tree = $this->tree($this->makeTree());

    $actionsToRestore = ! empty($this->mountedActions)
        ? $this->mountedActions
        : $this->preMountedActionsSnapshot;

    if (filled($actionsToRestore) && ! empty($this->cacheMountedActions($actionsToRestore))) {
        $this->mountedActions = $actionsToRestore;
    } else {
        $this->cacheMountedActions($this->mountedActions);
    }
}
```