### PR TITLE
Fix root node detection when frontend sends "-1" instead of null

### DIFF
--- a/src/Concerns/InteractsWithTree.php
+++ b/src/Concerns/InteractsWithTree.php
@@ -111,11 +111,16 @@ trait InteractsWithTree
     protected function isRootValue(mixed $value): bool
     {
         $rootValue = $this->getRootParentValue();
-        
+    
+        if ($rootValue === null) {
+            return $value === null
+                || $value === ''
+                || $value === -1
+                || $value === '-1';
+        }
         // Loose comparison to handle -1 vs "-1" etc
         return $value == $rootValue;
     }
-
     protected function buildNestedArray($nodes, $parentId = null): array
     {
         $branch = [];


### PR DESCRIPTION
## Problem

When dragging root nodes in Filament Tree View, the frontend sends `-1` as the parent ID.

The package expects root nodes to use `null` (via `getParentKeyDefaultValue()`), but the current `isRootValue()` implementation only performs a loose comparison:

```php
return $value == $rootValue;
```
Issue : #36